### PR TITLE
:sparkles: Added buttons for revision and reviser

### DIFF
--- a/frontend/src/infrastructure/view/pages/Convocations/ConvocatoryDetails/ConvocatoryDetails.scss
+++ b/frontend/src/infrastructure/view/pages/Convocations/ConvocatoryDetails/ConvocatoryDetails.scss
@@ -1,6 +1,32 @@
 .ConvocatoryDetails {
   padding: 0% 10%;
   margin-top: 5rem;
+  .revision-extras {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    .buttons {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      button {
+        border: none;
+        outline: none;
+        cursor: pointer;
+        border-radius: 2rem;
+        width: 8rem;
+        height: 2rem;
+        background-color: #7e254e;
+        margin-left: 4rem;
+      }
+      .aprove {
+        background-color: #05e200;
+      }
+      .desestimate {
+        background-color: #ff0000;
+      }
+    }
+  }
   .Convocatory {
     background-color: white;
     border: 1px solid #eaeaea;

--- a/frontend/src/infrastructure/view/pages/Convocations/ConvocatoryDetails/ConvocatoryDetails.tsx
+++ b/frontend/src/infrastructure/view/pages/Convocations/ConvocatoryDetails/ConvocatoryDetails.tsx
@@ -13,10 +13,28 @@ import { InputTextArea } from '../../../components/atoms/InputTextArea';
 import { SubmitButton } from '../../../components/atoms/SubmitButton';
 
 export const ConvocatoryDetails: React.FC<{}> = () => {
+  const isRevision = true;
+  const isReviser = true;
   const convocatory = exampleConvocatory.Convocatory as Convocatory;
   const auth = React.useContext(Context);
   return (
     <div className="ConvocatoryDetails">
+      {
+        (isRevision || isReviser) &&
+        <div className="revision-extras">
+          <h2>Convocatoria publicada por {convocatory.organizer}</h2>
+          <div className="buttons">
+            {
+              isRevision &&
+              <><button>Editar</button>
+                <button className="aprove">Aprobar</button></> ||
+              isReviser && <button>Voluntarios</button>
+            }
+            <button className="desestimate">Desestimar</button>
+          </div>
+        </div>
+
+      }
       <div className="Convocatory">
         <div className="Img-title-container">
           <Image source={convocatory.imageURL} description=""></Image>

--- a/frontend/src/infrastructure/view/pages/Convocations/ConvocatoryDetails/ConvocatoryDetails.tsx
+++ b/frontend/src/infrastructure/view/pages/Convocations/ConvocatoryDetails/ConvocatoryDetails.tsx
@@ -13,22 +13,22 @@ import { InputTextArea } from '../../../components/atoms/InputTextArea';
 import { SubmitButton } from '../../../components/atoms/SubmitButton';
 
 export const ConvocatoryDetails: React.FC<{}> = () => {
-  const isRevision = true;
-  const isReviser = true;
+  const isReadyForRevision = true;
+  const isUserReviser = true;
   const convocatory = exampleConvocatory.Convocatory as Convocatory;
   const auth = React.useContext(Context);
   return (
     <div className="ConvocatoryDetails">
       {
-        (isRevision || isReviser) &&
+        (isReadyForRevision || isUserReviser) &&
         <div className="revision-extras">
           <h2>Convocatoria publicada por {convocatory.organizer}</h2>
           <div className="buttons">
             {
-              isRevision &&
+              isReadyForRevision &&
               <><button>Editar</button>
                 <button className="aprove">Aprobar</button></> ||
-              isReviser && <button>Voluntarios</button>
+              isUserReviser && <button>Voluntarios</button>
             }
             <button className="desestimate">Desestimar</button>
           </div>


### PR DESCRIPTION
## Proposed changes

Small changes including the necessary logic for showing the buttons needded for the revision of a convocatory. Missing the context check for knowing if the current logged user is a reviser. Also mising the volunteers page for each convocatory.

## Types of changes

What types of changes does your code introduce to HuellaPositiva?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
